### PR TITLE
Fix Debian updater step failure and update Debian live versions to 13.0.0

### DIFF
--- a/.github/debian-updater.js
+++ b/.github/debian-updater.js
@@ -53,6 +53,12 @@ function updateVersion(err, parsedTorrent) {
   if (arch == 'x86') arch = 'i386';
   if (de == 'no desktop environment') de = 'standard';
 
+  // Skip if no corresponding version exists (e.g., new desktop environment variant)
+  if (!correspondingVersion) {
+    console.log(`Skipping ${parsedTorrent['name']}: No matching version found for arch=${arch}, de=${de}`);
+    return;
+  }
+
   if (correspondingVersion['version'] != versionNumber) {
 
     correspondingVersion['version'] = versionNumber;

--- a/distros.json
+++ b/distros.json
@@ -183,7 +183,7 @@
           "desktop-environment": "Cinnamon",
           "magnet-url": "magnet:?xt=urn:btih:209242862e5860bb9c0cc43aae05e6c30e1340a6&dn=debian-live-13.0.0-amd64-cinnamon.iso",
           "direct-download-url": "https://cdimage.debian.org/debian-cd/current-live/amd64/iso-hybrid/debian-live-13.0.0-amd64-cinnamon.iso",
-          "file-size": null
+          "file-size": 4043309056
         },
         {
           "arch": "amd64",
@@ -191,7 +191,7 @@
           "desktop-environment": "Gnome",
           "magnet-url": "magnet:?xt=urn:btih:17ddde7c8d80fc36dc04d053c9ac717ab53da75b&dn=debian-live-13.0.0-amd64-gnome.iso",
           "direct-download-url": "https://cdimage.debian.org/debian-cd/current-live/amd64/iso-hybrid/debian-live-13.0.0-amd64-gnome.iso",
-          "file-size": null
+          "file-size": 4039360512
         },
         {
           "arch": "amd64",
@@ -199,7 +199,7 @@
           "desktop-environment": "KDE",
           "magnet-url": "magnet:?xt=urn:btih:6951112a82a5e93bb90b186b4d95ff8484bd9bef&dn=debian-live-13.0.0-amd64-kde.iso",
           "direct-download-url": "https://cdimage.debian.org/debian-cd/current-live/amd64/iso-hybrid/debian-live-13.0.0-amd64-kde.iso",
-          "file-size": null
+          "file-size": 4127195136
         },
         {
           "arch": "amd64",
@@ -207,7 +207,7 @@
           "desktop-environment": "LXDE",
           "magnet-url": "magnet:?xt=urn:btih:ba01d15c639ef2cfb31baa8fe3d884cdc6e56601&dn=debian-live-13.0.0-amd64-lxde.iso",
           "direct-download-url": "https://cdimage.debian.org/debian-cd/current-live/amd64/iso-hybrid/debian-live-13.0.0-amd64-lxde.iso",
-          "file-size": null
+          "file-size": 3741319168
         },
         {
           "arch": "amd64",
@@ -215,7 +215,7 @@
           "desktop-environment": "LXQt",
           "magnet-url": "magnet:?xt=urn:btih:d428aaad1e18ac23028ad64337137d47d697e6a4&dn=debian-live-13.0.0-amd64-lxqt.iso",
           "direct-download-url": "https://cdimage.debian.org/debian-cd/current-live/amd64/iso-hybrid/debian-live-13.0.0-amd64-lxqt.iso",
-          "file-size": null
+          "file-size": 3925868544
         },
         {
           "arch": "amd64",
@@ -223,7 +223,7 @@
           "desktop-environment": "MATE",
           "magnet-url": "magnet:?xt=urn:btih:7456a8bf73c06d4cc30023f52480e05c10a54f4a&dn=debian-live-13.0.0-amd64-mate.iso",
           "direct-download-url": "https://cdimage.debian.org/debian-cd/current-live/amd64/iso-hybrid/debian-live-13.0.0-amd64-mate.iso",
-          "file-size": null
+          "file-size": 3901456384
         },
         {
           "arch": "amd64",
@@ -231,7 +231,7 @@
           "desktop-environment": "No Desktop Environment",
           "magnet-url": "magnet:?xt=urn:btih:a10ed35dea39f713c86a0f366aadc9e453f94768&dn=debian-live-13.0.0-amd64-standard.iso",
           "direct-download-url": "https://cdimage.debian.org/debian-cd/current-live/amd64/iso-hybrid/debian-live-13.0.0-amd64-standard.iso",
-          "file-size": null
+          "file-size": 1959100416
         },
         {
           "arch": "amd64",
@@ -239,7 +239,7 @@
           "desktop-environment": "Xfce",
           "magnet-url": "magnet:?xt=urn:btih:e10b0430c3b82d31bac282249c83ce5be0da9826&dn=debian-live-13.0.0-amd64-xfce.iso",
           "direct-download-url": "https://cdimage.debian.org/debian-cd/current-live/amd64/iso-hybrid/debian-live-13.0.0-amd64-xfce.iso",
-          "file-size": null
+          "file-size": 3767500800
         }
       ],
       "trackers": [

--- a/distros.json
+++ b/distros.json
@@ -179,67 +179,67 @@
       "versions": [
         {
           "arch": "amd64",
-          "version": "12.11.0",
+          "version": "13.0.0",
           "desktop-environment": "Cinnamon",
-          "magnet-url": "magnet:?xt=urn:btih:9dcda64a3b44c7b85f33b5463749c070622909ff&dn=debian-live-12.11.0-amd64-cinnamon.iso",
-          "direct-download-url": "https://cdimage.debian.org/debian-cd/current-live/amd64/iso-hybrid/debian-live-12.11.0-amd64-cinnamon.iso",
-          "file-size": 3452731392
+          "magnet-url": "magnet:?xt=urn:btih:209242862e5860bb9c0cc43aae05e6c30e1340a6&dn=debian-live-13.0.0-amd64-cinnamon.iso",
+          "direct-download-url": "https://cdimage.debian.org/debian-cd/current-live/amd64/iso-hybrid/debian-live-13.0.0-amd64-cinnamon.iso",
+          "file-size": null
         },
         {
           "arch": "amd64",
-          "version": "12.11.0",
+          "version": "13.0.0",
           "desktop-environment": "Gnome",
-          "magnet-url": "magnet:?xt=urn:btih:60d89907d96f59afa1d1c34562867ffd81329264&dn=debian-live-12.11.0-amd64-gnome.iso",
-          "direct-download-url": "https://cdimage.debian.org/debian-cd/current-live/amd64/iso-hybrid/debian-live-12.11.0-amd64-gnome.iso",
-          "file-size": 3519774720
+          "magnet-url": "magnet:?xt=urn:btih:17ddde7c8d80fc36dc04d053c9ac717ab53da75b&dn=debian-live-13.0.0-amd64-gnome.iso",
+          "direct-download-url": "https://cdimage.debian.org/debian-cd/current-live/amd64/iso-hybrid/debian-live-13.0.0-amd64-gnome.iso",
+          "file-size": null
         },
         {
           "arch": "amd64",
-          "version": "12.11.0",
+          "version": "13.0.0",
           "desktop-environment": "KDE",
-          "magnet-url": "magnet:?xt=urn:btih:c10f21c5b7d50473bebb206983ff4306c6b67e9b&dn=debian-live-12.11.0-amd64-kde.iso",
-          "direct-download-url": "https://cdimage.debian.org/debian-cd/current-live/amd64/iso-hybrid/debian-live-12.11.0-amd64-kde.iso",
-          "file-size": 3566567424
+          "magnet-url": "magnet:?xt=urn:btih:6951112a82a5e93bb90b186b4d95ff8484bd9bef&dn=debian-live-13.0.0-amd64-kde.iso",
+          "direct-download-url": "https://cdimage.debian.org/debian-cd/current-live/amd64/iso-hybrid/debian-live-13.0.0-amd64-kde.iso",
+          "file-size": null
         },
         {
           "arch": "amd64",
-          "version": "12.11.0",
+          "version": "13.0.0",
           "desktop-environment": "LXDE",
-          "magnet-url": "magnet:?xt=urn:btih:29bfa3c0f5ea9cb9088184349782c1e2466647bb&dn=debian-live-12.11.0-amd64-lxde.iso",
-          "direct-download-url": "https://cdimage.debian.org/debian-cd/current-live/amd64/iso-hybrid/debian-live-12.11.0-amd64-lxde.iso",
-          "file-size": 3225354240
+          "magnet-url": "magnet:?xt=urn:btih:ba01d15c639ef2cfb31baa8fe3d884cdc6e56601&dn=debian-live-13.0.0-amd64-lxde.iso",
+          "direct-download-url": "https://cdimage.debian.org/debian-cd/current-live/amd64/iso-hybrid/debian-live-13.0.0-amd64-lxde.iso",
+          "file-size": null
         },
         {
           "arch": "amd64",
-          "version": "12.11.0",
+          "version": "13.0.0",
           "desktop-environment": "LXQt",
-          "magnet-url": "magnet:?xt=urn:btih:6e2e341631a7a5dff5072959e6a4e4724a576143&dn=debian-live-12.11.0-amd64-lxqt.iso",
-          "direct-download-url": "https://cdimage.debian.org/debian-cd/current-live/amd64/iso-hybrid/debian-live-12.11.0-amd64-lxqt.iso",
-          "file-size": 3285123072
+          "magnet-url": "magnet:?xt=urn:btih:d428aaad1e18ac23028ad64337137d47d697e6a4&dn=debian-live-13.0.0-amd64-lxqt.iso",
+          "direct-download-url": "https://cdimage.debian.org/debian-cd/current-live/amd64/iso-hybrid/debian-live-13.0.0-amd64-lxqt.iso",
+          "file-size": null
         },
         {
           "arch": "amd64",
-          "version": "12.11.0",
+          "version": "13.0.0",
           "desktop-environment": "MATE",
-          "magnet-url": "magnet:?xt=urn:btih:480d2dc5c1d1018deb6db3d7e69500823dd68f0a&dn=debian-live-12.11.0-amd64-mate.iso",
-          "direct-download-url": "https://cdimage.debian.org/debian-cd/current-live/amd64/iso-hybrid/debian-live-12.11.0-amd64-mate.iso",
-          "file-size": 3338665984
+          "magnet-url": "magnet:?xt=urn:btih:7456a8bf73c06d4cc30023f52480e05c10a54f4a&dn=debian-live-13.0.0-amd64-mate.iso",
+          "direct-download-url": "https://cdimage.debian.org/debian-cd/current-live/amd64/iso-hybrid/debian-live-13.0.0-amd64-mate.iso",
+          "file-size": null
         },
         {
           "arch": "amd64",
-          "version": "12.11.0",
+          "version": "13.0.0",
           "desktop-environment": "No Desktop Environment",
-          "magnet-url": "magnet:?xt=urn:btih:dbdc69420327c44166335960945c3ebc06ee4f4c&dn=debian-live-12.11.0-amd64-standard.iso",
-          "direct-download-url": "https://cdimage.debian.org/debian-cd/current-live/amd64/iso-hybrid/debian-live-12.11.0-amd64-standard.iso",
-          "file-size": 1589166080
+          "magnet-url": "magnet:?xt=urn:btih:a10ed35dea39f713c86a0f366aadc9e453f94768&dn=debian-live-13.0.0-amd64-standard.iso",
+          "direct-download-url": "https://cdimage.debian.org/debian-cd/current-live/amd64/iso-hybrid/debian-live-13.0.0-amd64-standard.iso",
+          "file-size": null
         },
         {
           "arch": "amd64",
-          "version": "12.11.0",
+          "version": "13.0.0",
           "desktop-environment": "Xfce",
-          "magnet-url": "magnet:?xt=urn:btih:c4ec4e572fb587e21e9e8763472475d2f3ce6ba7&dn=debian-live-12.11.0-amd64-xfce.iso",
-          "direct-download-url": "https://cdimage.debian.org/debian-cd/current-live/amd64/iso-hybrid/debian-live-12.11.0-amd64-xfce.iso",
-          "file-size": 3242065920
+          "magnet-url": "magnet:?xt=urn:btih:e10b0430c3b82d31bac282249c83ce5be0da9826&dn=debian-live-13.0.0-amd64-xfce.iso",
+          "direct-download-url": "https://cdimage.debian.org/debian-cd/current-live/amd64/iso-hybrid/debian-live-13.0.0-amd64-xfce.iso",
+          "file-size": null
         }
       ],
       "trackers": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "dependencies": {
-    "parse-torrent": "^10.0.1",
-    "rss-parser": "^3.12.0"
+    "cheerio": "^1.1.2",
+    "parse-torrent": "^10.0.2",
+    "rss-parser": "^3.13.0"
   },
   "type": "module"
 }


### PR DESCRIPTION
## Summary
- Fixes failure in Debian updater step by skipping updates when no matching version is found
- Updates Debian live ISO versions from 12.11.0 to 13.0.0 in `distros.json`
- Updates magnet URLs and direct download URLs accordingly
- Sets file sizes to `null` for new Debian live versions
- Updates dependencies: adds `cheerio` and bumps `parse-torrent` and `rss-parser` versions

## Changes

### Debian Updater Script
- Added a check to skip processing if no corresponding version exists for the given architecture and desktop environment
- Logs a message when skipping such entries to avoid silent failures

### Distribution Metadata (`distros.json`)
- Updated all Debian live ISO versions from 12.11.0 to 13.0.0
- Updated magnet URLs and direct download URLs to point to the new Debian 13.0.0 images
- Set file sizes to `null` for the updated Debian live versions

### Package Dependencies (`package.json`)
- Added `cheerio` dependency at version `^1.1.2`
- Updated `parse-torrent` to `^10.0.2`
- Updated `rss-parser` to `^3.13.0`

## Test plan
- Verify that the Debian updater no longer fails when encountering new or unmatched desktop environment variants
- Confirm that Debian live ISO versions and URLs are correctly updated and accessible
- Run existing tests to ensure no regressions in torrent parsing and RSS feed handling
- Validate that the new dependencies are installed and functioning as expected

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/46e2455e-0e73-4915-8116-73ce89604f94