### PR TITLE
Improve Arch Linux updater with retry logic and enhanced error handling

### DIFF
--- a/.github/arch-updater.js
+++ b/.github/arch-updater.js
@@ -58,7 +58,7 @@ async function parseTorrentWithRetry(url, maxRetries = 3) {
 
 async function updateArch() {
   try {
-    const feed = await fetchWithRetry('https://www.archlinux.org/feeds/releases/');
+    const feed = await fetchWithRetry('https://archlinux.org/feeds/releases/');
     
     if (!feed || !feed.items || feed.items.length === 0) {
       console.log('No items found in RSS feed');

--- a/.github/arch-updater.js
+++ b/.github/arch-updater.js
@@ -6,28 +6,95 @@ var distros = JSON.parse(fs.readFileSync('distros.json'));
 
 const distroIndex = distros['distros'].findIndex(distro => distro['name'] == 'Arch');
 
-const parser = new Parser();
-parser.parseURL('https://www.archlinux.org/feeds/releases/', function(err, feed) {
+const parser = new Parser({
+  timeout: 30000,
+  headers: {
+    'User-Agent': 'Mozilla/5.0 (compatible; LinuxExchange/1.0)'
+  }
+});
 
-  if (err) throw err;
+async function fetchWithRetry(url, maxRetries = 3) {
+  for (let i = 0; i < maxRetries; i++) {
+    try {
+      console.log(`Attempt ${i + 1} to fetch RSS feed from ${url}`);
+      const feed = await parser.parseURL(url);
+      console.log('Successfully fetched RSS feed');
+      return feed;
+    } catch (error) {
+      console.error(`Attempt ${i + 1} failed:`, error.message);
+      if (i === maxRetries - 1) {
+        throw error;
+      }
+      // Wait before retrying (exponential backoff)
+      const waitTime = Math.min(1000 * Math.pow(2, i), 10000);
+      console.log(`Waiting ${waitTime}ms before retry...`);
+      await new Promise(resolve => setTimeout(resolve, waitTime));
+    }
+  }
+}
 
-  remote(feed['items'][0]['enclosure']['url'], function(err, parsedTorrent) {
+async function parseTorrentWithRetry(url, maxRetries = 3) {
+  for (let i = 0; i < maxRetries; i++) {
+    try {
+      console.log(`Attempt ${i + 1} to parse torrent from ${url}`);
+      return await new Promise((resolve, reject) => {
+        remote(url, (err, parsedTorrent) => {
+          if (err) reject(err);
+          else resolve(parsedTorrent);
+        });
+      });
+    } catch (error) {
+      console.error(`Attempt ${i + 1} failed:`, error.message);
+      if (i === maxRetries - 1) {
+        throw error;
+      }
+      // Wait before retrying
+      const waitTime = Math.min(1000 * Math.pow(2, i), 10000);
+      console.log(`Waiting ${waitTime}ms before retry...`);
+      await new Promise(resolve => setTimeout(resolve, waitTime));
+    }
+  }
+}
 
-    if (err) throw err;
+async function updateArch() {
+  try {
+    const feed = await fetchWithRetry('https://www.archlinux.org/feeds/releases/');
+    
+    if (!feed || !feed.items || feed.items.length === 0) {
+      console.log('No items found in RSS feed');
+      return;
+    }
 
+    const latestItem = feed.items[0];
+    
+    if (!latestItem.enclosure || !latestItem.enclosure.url) {
+      console.log('No torrent URL found in latest release');
+      return;
+    }
+
+    console.log(`Processing latest release: ${latestItem.title}`);
+    
+    const parsedTorrent = await parseTorrentWithRetry(latestItem.enclosure.url);
+    
     var version = distros['distros'][distroIndex]['versions'][0];
 
-    if (version['version'] != feed['items'][0]['title']) {
-
-      version['version'] = feed['items'][0]['title'];
-      version['magnet-url'] = 'magnet:?xt=urn:btih:' + parsedTorrent['infoHash'] + '&dn=' + parsedTorrent['name'];
-      version['direct-download-url'] = 'https://mirrors.kernel.org/archlinux/iso/' + feed['items'][0]['title'] + '/' + parsedTorrent['name'];
+    if (version['version'] != latestItem.title) {
+      console.log(`Updating version from ${version['version']} to ${latestItem.title}`);
+      
+      version['version'] = latestItem.title;
+      version['magnet-url'] = 'magnet:?xt=urn:btih:' + parsedTorrent.infoHash + '&dn=' + parsedTorrent.name;
+      version['direct-download-url'] = 'https://mirrors.kernel.org/archlinux/iso/' + latestItem.title + '/' + parsedTorrent.name;
       version['file-size'] = null;
       
       fs.writeFileSync('distros.json', JSON.stringify(distros, null, 2));
-
+      console.log('Successfully updated distros.json');
+    } else {
+      console.log('Version is already up to date');
     }
+  } catch (error) {
+    console.error('Failed to update Arch Linux information:', error);
+    process.exit(1);
+  }
+}
 
-  });
-
-});
+updateArch();


### PR DESCRIPTION
## Summary
- Refactors Arch Linux updater script to use async/await
- Adds retry logic with exponential backoff for fetching RSS feed and parsing torrent
- Improves error handling and logging for better reliability
- Updates user-agent header and timeout for RSS feed parser

## Changes

### Arch Updater Script (.github/arch-updater.js)
- Replaced callback-based RSS feed parsing with async function `fetchWithRetry` that retries up to 3 times on failure
- Added `parseTorrentWithRetry` function to retry torrent parsing with exponential backoff
- Wrapped main update logic in async `updateArch` function with try/catch for error handling
- Added detailed console logs for each retry attempt and success/failure states
- Updated distros.json only if a new Arch Linux version is detected
- Set user-agent header and increased timeout in RSS parser configuration

## Test plan
- [x] Verify script successfully fetches and parses latest Arch Linux release RSS feed
- [x] Confirm retry attempts occur on simulated network failures
- [x] Check that distros.json updates only when a new version is available
- [x] Validate error messages and logs appear correctly on failures
- [x] Ensure script exits with error code on unrecoverable errors

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/c4b8f28f-ebd6-45d9-88d0-c440621f3945